### PR TITLE
Fixed Item Subclass Method Overrides and Added empty search case

### DIFF
--- a/src/main/java/slate/items/Beaker.java
+++ b/src/main/java/slate/items/Beaker.java
@@ -5,23 +5,11 @@ import slate.bases.ItemBase;
 public class Beaker extends ItemBase {
 
 	public Beaker() {
-		// TODO Auto-generated constructor stub
+		name = "Beaker";
+		weight = 7;
 	}
 
 	public Beaker(ItemBase item) {
 		super(item);
-		// TODO Auto-generated constructor stub
 	}
-	
-	@Override
-	public int getWeight() {
-		// TODO Auto-generated method stub
-		return 7;
-	}
-	@Override
-	public String getName() {
-		// TODO Auto-generated method stub
-		return "Beaker";
-	}
-
 }

--- a/src/main/java/slate/items/Key.java
+++ b/src/main/java/slate/items/Key.java
@@ -5,21 +5,11 @@ import slate.bases.ItemBase;
 public class Key extends ItemBase {
 
 	public Key() {
-		// TODO Auto-generated constructor stub
+		name = "Key";
+		weight = 1;
 	}
 
 	public Key(ItemBase item) {
 		super(item);
-		// TODO Auto-generated constructor stub
 	}
-	
-	@Override
-	public int getWeight() {
-		return 1;
-	}
-	@Override
-	public String getName() {
-		return "key";
-	}
-
 }

--- a/src/main/java/slate/items/LogBook.java
+++ b/src/main/java/slate/items/LogBook.java
@@ -5,22 +5,11 @@ import slate.bases.ItemBase;
 public class LogBook extends ItemBase {
 
 	public LogBook() {
-		// TODO Auto-generated constructor stub
+		name = "Log Book";
+		weight = 2;
 	}
 
 	public LogBook(ItemBase item) {
 		super(item);
-		// TODO Auto-generated constructor stub
 	}
-	@Override
-	public int getWeight() {
-		// TODO Auto-generated method stub
-		return 2;
-	}
-	@Override
-	public String getName() {
-		// TODO Auto-generated method stub
-		return "Log book";
-	}
-
 }

--- a/src/main/java/slate/items/Muffin.java
+++ b/src/main/java/slate/items/Muffin.java
@@ -5,22 +5,11 @@ import slate.bases.ItemBase;
 public class Muffin extends ItemBase {
 
 	public Muffin() {
-		// TODO Auto-generated constructor stub
+		name = "Muffin";
+		weight = 3;
 	}
 
 	public Muffin(ItemBase item) {
 		super(item);
-		// TODO Auto-generated constructor stub
 	}
-	@Override
-	public int getWeight() {
-		// TODO Auto-generated method stub
-		return 3;
-	}
-	@Override
-	public String getName() {
-		// TODO Auto-generated method stub
-		return "Muffin";
-	}
-
 }

--- a/src/main/java/slate/items/Pen.java
+++ b/src/main/java/slate/items/Pen.java
@@ -6,23 +6,11 @@ import slate.bases.ItemBase;
 public class Pen extends ItemBase {
 
 	public Pen() {
-		// TODO Auto-generated constructor stub
+		name = "Pen";
+		weight = 3;
 	}
 
 	public Pen(ItemBase item) {
 		super(item);
-		// TODO Auto-generated constructor stub
 	}
-	
-	@Override
-	public int getWeight() {
-		// TODO Auto-generated method stub
-		return 3;
-	}
-	@Override
-	public String getName() {
-		// TODO Auto-generated method stub
-		return "Pen";
-	}
-
 }

--- a/src/main/java/slate/items/Poison.java
+++ b/src/main/java/slate/items/Poison.java
@@ -5,22 +5,11 @@ import slate.bases.ItemBase;
 public class Poison extends ItemBase {
 
 	public Poison() {
-		// TODO Auto-generated constructor stub
+		name = "Poison";
+		weight = 5;
 	}
 
 	public Poison(ItemBase item) {
 		super(item);
-		// TODO Auto-generated constructor stub
 	}
-	@Override
-	public int getWeight() {
-		// TODO Auto-generated method stub
-		return 5;
-	}
-	@Override
-	public String getName() {
-		// TODO Auto-generated method stub
-		return "Poison";
-	}
-
 }

--- a/src/main/java/slate/items/Sword.java
+++ b/src/main/java/slate/items/Sword.java
@@ -6,22 +6,11 @@ import slate.bases.ItemBase;
 public class Sword extends ItemBase {
 
 	public Sword() {
-		// TODO Auto-generated constructor stub
+		name = "Sword";
+		weight = 5;
 	}
 
 	public Sword(ItemBase item) {
 		super(item);
-		// TODO Auto-generated constructor stub
 	}
-	@Override
-	public int getWeight() {
-		// TODO Auto-generated method stub
-		return 5;
-	}
-	@Override
-	public String getName() {
-		// TODO Auto-generated method stub
-		return "sword";
-	}
-
 }

--- a/src/main/java/slate/items/TestItem.java
+++ b/src/main/java/slate/items/TestItem.java
@@ -5,13 +5,11 @@ import slate.bases.ItemBase;
 public class TestItem extends ItemBase {
 
 	public TestItem() {
-		// TODO Auto-generated constructor stub
 		name = "Test Item";
 		weight = 1;
 	}
 
 	public TestItem(ItemBase item) {
 		super(item);
-		// TODO Auto-generated constructor stub
 	}
 }

--- a/src/main/java/slate/parser/Command.java
+++ b/src/main/java/slate/parser/Command.java
@@ -386,7 +386,7 @@ public class Command{
         }
     }
 
-    //SEARCH ROOM
+    //SEARCH
     class SearchCommand implements CommInterface{
 
         String data;
@@ -408,6 +408,8 @@ public class Command{
                     for (Inventory.Stack item : items) {
                         System.out.println(String.format("- %s x%d", item.name, item.count));
                     }
+                }else{
+                    System.out.println("I can't find any loose items here.");
                 }
 
                 ArrayList<Inventory> inventories = game.current_map.nav.getCurrentRoom().getInventories();


### PR DESCRIPTION
Fixes weird issue with overriding item methods instead of defining variables, and adds a case for an empty room to the search command